### PR TITLE
Add native benchmark and verbose timing/counters for Butteraugli hotspot

### DIFF
--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -322,5 +322,21 @@ int main(int argc, char** argv) {
   }
 
   WriteFileOrDie(argv[opt_idx + 1], out_data);
+
+  if (verbose) {
+    const double compare_avg_ms = stats.butteraugli_compare_calls == 0
+        ? 0.0
+        : stats.butteraugli_compare_total_ms / stats.butteraugli_compare_calls;
+    fprintf(stderr,
+            "Instrumentation: Compare calls=%llu total_ms=%.3f avg_ms=%.3f\n",
+            static_cast<unsigned long long>(stats.butteraugli_compare_calls),
+            stats.butteraugli_compare_total_ms, compare_avg_ms);
+    fprintf(stderr,
+            "Instrumentation: SelectFrequencyMasking total_ms=%.3f candidate_evals=%llu\n",
+            stats.select_frequency_masking_total_ms,
+            static_cast<unsigned long long>(
+                stats.select_frequency_masking_candidate_evals));
+  }
+
   return 0;
 }

--- a/guetzli/stats.h
+++ b/guetzli/stats.h
@@ -18,6 +18,7 @@
 #define GUETZLI_STATS_H_
 
 #include <cstdio>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>
@@ -35,6 +36,11 @@ struct ProcessStats {
   std::map<std::string, int> counters;
   std::string* debug_output = nullptr;
   FILE* debug_output_file = nullptr;
+
+  uint64_t butteraugli_compare_calls = 0;
+  double butteraugli_compare_total_ms = 0.0;
+  double select_frequency_masking_total_ms = 0.0;
+  uint64_t select_frequency_masking_candidate_evals = 0;
 
   std::string filename;
 };

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+GUETZLI=${1:-bin/Release/guetzli}
+INPUT=${2:-bin/Release/in.jpg}
+QUALITY=${QUALITY:-90}
+RUNS=${RUNS:-7}
+
+if [[ ! -x "$GUETZLI" ]]; then
+  echo "missing executable: $GUETZLI" >&2
+  exit 1
+fi
+if [[ ! -f "$INPUT" ]]; then
+  echo "missing input: $INPUT" >&2
+  exit 1
+fi
+
+TIME_CMD=""
+if [[ -x /usr/bin/time ]]; then
+  TIME_CMD="/usr/bin/time -f %e"
+else
+  echo "warning: /usr/bin/time not found, using shell time builtin" >&2
+fi
+
+times=()
+for i in $(seq 1 "$RUNS"); do
+  out="/tmp/guetzli-bench-$i.jpg"
+  if [[ -n "$TIME_CMD" ]]; then
+    t=$($TIME_CMD "$GUETZLI" --quality "$QUALITY" "$INPUT" "$out" 2>&1 >/dev/null)
+  else
+    TIMEFORMAT='%R'
+    t=$({ time "$GUETZLI" --quality "$QUALITY" "$INPUT" "$out" >/dev/null; } 2>&1)
+  fi
+  times+=("$t")
+  echo "run $i: $t"
+done
+
+
+median=$(printf '%s\n' "${times[@]}" | sort -n | awk 'NR==4{print $1}')
+echo "median: $median"


### PR DESCRIPTION
### Motivation
- Gather a native wall-clock baseline and lightweight runtime counters to guide optimizations for the butteraugli hotspot identified during profiling.
- Keep changes minimal and non-invasive and print instrumentation only when `--verbose` is enabled.
- Provide a simple harness to run repeatable median wall-time measurements and avoid disk noise by writing outputs to `/tmp`.

### Description
- Add `tools/bench.sh` to run 7 iterations of `bin/Release/guetzli` (default `--quality 90`) and print per-run times and the median, writing outputs to `/tmp` (with `/usr/bin/time` fallback to shell `time`).
- Extend `ProcessStats` (`guetzli/stats.h`) with counters/timers: `butteraugli_compare_calls`, `butteraugli_compare_total_ms`, `select_frequency_masking_total_ms`, and `select_frequency_masking_candidate_evals`.
- Instrument `ButteraugliComparator::Compare()` (`guetzli/butteraugli_comparator.cc`) to increment `butteraugli_compare_calls` and accumulate elapsed ms for each call using `std::chrono`.
- Instrument `Processor::SelectFrequencyMasking()` (`guetzli/processor.cc`) to time the whole function and increment `select_frequency_masking_candidate_evals` inside the candidate ordering loops.
- Print a small instrumentation summary at program end in `main` (`guetzli/guetzli.cc`) when `--verbose` is enabled; output includes compare calls/total/avg and select-frequency totals/candidate-evals.

### Testing
- Built with `make -j$(nproc)` and the build succeeded after the changes.
- Baseline (Phase 0 native) measured with a shell `time` loop on `bin/Release/in.jpg` (`--quality 90`) produced these 7 runs (s): `20.785, 21.184, 20.812, 20.607, 21.290, 20.590, 20.346` and median `20.785s`.
- After instrumentation (Phase 1) `tools/bench.sh` runs (7) produced: `20.969, 20.806, 21.411, 20.399, 20.356, 21.257, 20.524` with median `20.806s`, which is approximately `-0.10%` change vs baseline (i.e., effectively neutral).
- One `--verbose` run printed instrumentation (Phase 1 counters): `Instrumentation: Compare calls=94 total_ms=17858.048 avg_ms=189.979` and `Instrumentation: SelectFrequencyMasking total_ms=19325.809 candidate_evals=1748305`.
- Ran `tools/bench.sh` and `bin/Release/guetzli --quality 90 --verbose ...` successfully.
- `tests/smoke_test.sh bin/Release/guetzli` failed in this environment due to missing external tools (`pngtopnm` and `cjpeg`); this is an environment limitation and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eca4fd464832994610f7b0c60d24a)