### PR TITLE
Add verbose Butteraugli Compare timing breakdown and reuse scratch buffers

### DIFF
--- a/guetzli/butteraugli_comparator.h
+++ b/guetzli/butteraugli_comparator.h
@@ -72,6 +72,12 @@ class ButteraugliComparator : public Comparator {
   int factor_x_;
   int factor_y_;
   std::vector<::butteraugli::ImageF> mask_xyz_;
+  std::vector<::butteraugli::ImageF> reference_opsin_;
+  std::vector<::butteraugli::ImageF> candidate_planes_;
+  ::butteraugli::ImageF diffmap_image_;
+  std::vector<std::vector<float>> candidate_linear_rgb_;
+  bool reference_precomputed_ = false;
+  double reference_precompute_ms_ = 0.0;
   std::vector<std::vector<std::vector<float>>> per_block_pregamma_;
   ::butteraugli::ButteraugliComparator comparator_;
   float distance_;


### PR DESCRIPTION
### Motivation

- Reduce per-call overhead in `ButteraugliComparator::Compare()` by avoiding repeated allocations and make hot-path costs observable via finer-grained timings.
- Cache expensive reference precompute work once so it is not recomputed on every `Compare()` and report that cost under `--verbose` to aid optimization.

### Description

- Added reusable scratch state to `ButteraugliComparator` including `reference_opsin_`, `candidate_planes_`, `diffmap_image_`, `candidate_linear_rgb_`, `reference_precomputed_`, and `reference_precompute_ms_` in `butteraugli_comparator.h`.
- Precompute and cache the reference Opsin representation in the constructor and record its one-time duration in `reference_precompute_ms_`.
- Added `CopyPackedToPlanes()` helper and refactored `Compare()` to reuse `candidate_linear_rgb_`, `candidate_planes_`, and `diffmap_image_` instead of reallocating per call and to accumulate `butteraugli_compare_total_ms` from a single measured `total_ms` value.
- When `--verbose` is enabled print a per-`Compare()` timing breakdown line `CompareTiming total_ms=... convert_ms=... diffmap_ms=... ref_precompute_ms=... ref_cached=...` to stderr via the existing debug path.

### Testing

- Ran `make -j4` and the build completed successfully.
- Ran `tests/smoke_test.sh` which failed in this environment due to missing external tools (`pngtopnm` and `cjpeg`) so the smoke script could not run to completion.
- Performed a verbose run `bin/Release/guetzli --verbose --quality 84 bin/Release/in_800.png /tmp/out_after.jpg` which printed instrumentation: `Compare calls=13 total_ms=10871.264 avg_ms=836.251` and `SelectFrequencyMasking total_ms=4363.480 candidate_evals=27549`, and emitted per-call breakdown lines showing `convert_ms ~7–8ms`, `diffmap_ms ~795–882ms`, and `ref_precompute_ms=145.910 ref_cached=1`.
- Ran a 7-iteration benchmark (median) comparing the modified binary against a baseline build, which measured a median time before = `17.208s`, after = `13.167s`, for a median speedup of `23.48%`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ef0f99b4c83299642084cfc7afd6b)