### PR TITLE
Optimize SelectFrequencyMasking with deterministic top-K candidate selection

### DIFF
--- a/guetzli/guetzli.cc
+++ b/guetzli/guetzli.cc
@@ -332,10 +332,18 @@ int main(int argc, char** argv) {
             static_cast<unsigned long long>(stats.butteraugli_compare_calls),
             stats.butteraugli_compare_total_ms, compare_avg_ms);
     fprintf(stderr,
-            "Instrumentation: SelectFrequencyMasking total_ms=%.3f candidate_evals=%llu\n",
+            "Instrumentation: SelectFrequencyMasking total_ms=%.3f "
+            "candidate_evals=%llu full_compare_calls=%llu top_k=%llu "
+            "fast_rejects=%llu\n",
             stats.select_frequency_masking_total_ms,
             static_cast<unsigned long long>(
-                stats.select_frequency_masking_candidate_evals));
+                stats.select_frequency_masking_candidate_evals),
+            static_cast<unsigned long long>(
+                stats.select_frequency_masking_full_compare_calls),
+            static_cast<unsigned long long>(
+                stats.select_frequency_masking_top_k),
+            static_cast<unsigned long long>(
+                stats.select_frequency_masking_fast_rejects));
   }
 
   return 0;

--- a/guetzli/stats.h
+++ b/guetzli/stats.h
@@ -41,6 +41,9 @@ struct ProcessStats {
   double butteraugli_compare_total_ms = 0.0;
   double select_frequency_masking_total_ms = 0.0;
   uint64_t select_frequency_masking_candidate_evals = 0;
+  uint64_t select_frequency_masking_full_compare_calls = 0;
+  uint64_t select_frequency_masking_top_k = 0;
+  uint64_t select_frequency_masking_fast_rejects = 0;
 
   std::string filename;
 };


### PR DESCRIPTION
### Motivation

- Reduce wall time dominated by full `Compare()` calls in `Processor::SelectFrequencyMasking` by avoiding sorting the entire candidate list while keeping final selection semantics.
- Add visibility into the SelectFrequencyMasking path with counters for candidate evaluations, full compare calls, top-K accepted candidates, and fast-rejects, and ensure deterministic behavior for reproducible outputs.

### Description

- Introduced a `Candidate` struct and a deterministic tie-breaker (`id`) and changed the per-iteration candidate list to keep only the top-K candidates using `std::nth_element` (with `kTopKCandidates = 20`) followed by a `std::sort` of the top-K subset.
- Preserved the existing candidate-eval accounting and added new counters to `ProcessStats`: `select_frequency_masking_full_compare_calls`, `select_frequency_masking_top_k`, and `select_frequency_masking_fast_rejects`.
- Increment `select_frequency_masking_full_compare_calls` immediately before invoking `Compare()` and update the verbose instrumentation in `guetzli.cc` to print the new counters alongside existing timing and candidate metrics.
- Changes applied in `guetzli/processor.cc`, `guetzli/stats.h`, and `guetzli/guetzli.cc`.

### Testing

- Built with `make -j4` and the build completed successfully.
- Ran `tests/smoke_test.sh bin/Release/guetzli` which failed in this environment due to missing external tools (`pngtopnm` / `cjpeg`) so the smoke test could not be fully exercised.
- Determinism check: ran two verbose runs `bin/Release/guetzli --verbose --quality 90 /tmp/bench_800.jpg` producing `/tmp/det_run1.jpg` and `/tmp/det_run2.jpg` and `sha256sum` matched (files identical).
- 7-iteration native benchmark via `RUNS=7 QUALITY=90 tools/bench.sh bin/Release/guetzli /tmp/bench_800.jpg` produced median runtime `0.198s` and verbose instrumentation snapshot: `Compare calls=30 total_ms=168.027 avg_ms=5.601` and `SelectFrequencyMasking total_ms=105.911 candidate_evals=2720 full_compare_calls=16 top_k=320 fast_rejects=2400`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f209b56f08329b532674aac603f3f)