### PR TITLE
Improve threading runtime, verbose profiling, and benchmark setup

### DIFF
--- a/guetzli/butteraugli_comparator.h
+++ b/guetzli/butteraugli_comparator.h
@@ -36,6 +36,7 @@ class ButteraugliComparator : public Comparator {
                         const float target_distance, ProcessStats* stats);
 
   void Compare(const OutputImage& img) override;
+  double ProxyDistance(const OutputImage& img) const override;
 
   void StartBlockComparisons() override;
   void FinishBlockComparisons() override;

--- a/guetzli/comparator.h
+++ b/guetzli/comparator.h
@@ -35,6 +35,7 @@ class Comparator {
   // inside the object. The provided image must have the same dimensions as the
   // baseline image.
   virtual void Compare(const OutputImage& img) = 0;
+  virtual double ProxyDistance(const OutputImage& img) const = 0;
 
   // Must be called before any CompareBlock() calls can be called.
   virtual void StartBlockComparisons() = 0;

--- a/guetzli/stats.h
+++ b/guetzli/stats.h
@@ -39,11 +39,18 @@ struct ProcessStats {
 
   uint64_t butteraugli_compare_calls = 0;
   double butteraugli_compare_total_ms = 0.0;
+  double butteraugli_color_convert_total_ms = 0.0;
+  double butteraugli_diffmap_total_ms = 0.0;
   double select_frequency_masking_total_ms = 0.0;
   uint64_t select_frequency_masking_candidate_evals = 0;
+  uint64_t select_frequency_masking_proxy_evals = 0;
   uint64_t select_frequency_masking_full_compare_calls = 0;
+  uint64_t select_frequency_masking_proxy_rejects = 0;
   uint64_t select_frequency_masking_top_k = 0;
   uint64_t select_frequency_masking_fast_rejects = 0;
+  uint64_t jpeg_encode_calls = 0;
+  double jpeg_encode_total_ms = 0.0;
+  int thread_count = 1;
 
   std::string filename;
 };

--- a/third_party/butteraugli/butteraugli/butteraugli.h
+++ b/third_party/butteraugli/butteraugli/butteraugli.h
@@ -104,6 +104,17 @@ double ButteraugliFuzzyInverse(double seek);
 bool ButteraugliAdaptiveQuantization(size_t xsize, size_t ysize,
     const std::vector<std::vector<float> > &rgb, std::vector<float> &quant);
 
+void SetThreadCount(int threads);
+int ThreadCount();
+
+struct RuntimeProfile {
+  uint64_t convolution_calls;
+  double convolution_ms;
+};
+
+void ResetRuntimeProfile();
+RuntimeProfile GetRuntimeProfile();
+
 // Implementation details, don't use anything below or your code will
 // break in the future.
 

--- a/tools/mkbench.sh
+++ b/tools/mkbench.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+in="${1:-bin/Release/in.jpg}"
+out="${2:-/tmp/bench_800.jpg}"
+
+if [[ ! -f "$in" ]]; then
+  echo "Input not found: $in" >&2
+  exit 1
+fi
+
+# Prefer ffmpeg if present.
+if command -v ffmpeg >/dev/null 2>&1; then
+  ffmpeg -y -loglevel error -i "$in" -vf "scale='if(gt(iw,ih),min(iw,800),-2)':'if(gt(ih,iw),min(ih,800),-2)'" "$out"
+  echo "Wrote $out using ffmpeg"
+  exit 0
+fi
+
+# Fallback: if image is already <=800x800, copy as-is.
+python - "$in" "$out" <<'PY'
+import sys
+src,dst=sys.argv[1],sys.argv[2]
+with open(src,'rb') as f:
+    b=f.read()
+if b[:2]!=b'\xff\xd8':
+    raise SystemExit('Input is not a JPEG and ffmpeg is unavailable')
+i=2
+w=h=None
+while i+9<len(b):
+    if b[i]!=0xFF:
+        i+=1; continue
+    m=b[i+1]
+    i+=2
+    if m in (0xD8,0xD9) or (0xD0<=m<=0xD7):
+        continue
+    if i+2>len(b): break
+    l=(b[i]<<8)|b[i+1]
+    if l<2 or i+l>len(b): break
+    if m in (0xC0,0xC1,0xC2,0xC3,0xC5,0xC6,0xC7,0xC9,0xCA,0xCB,0xCD,0xCE,0xCF):
+        h=(b[i+3]<<8)|b[i+4]
+        w=(b[i+5]<<8)|b[i+6]
+        break
+    i+=l
+if w is None:
+    raise SystemExit('Failed to parse JPEG dimensions')
+if w>800 or h>800:
+    raise SystemExit('Need ffmpeg (or similar) to resize; current image is larger than 800x800')
+open(dst,'wb').write(b)
+print(f'Wrote {dst} by copy ({w}x{h})')
+PY


### PR DESCRIPTION
### Motivation
- Reduce wall-time for the dominant Butteraugli work (Convolution) by enabling safe CPU parallelism while preserving deterministic outputs. 
- Expose accurate native wall-time breakdowns (not Valgrind) for hot-paths to guide further optimisation without adding noise during normal runs. 
- Avoid wasted expensive Butteraugli comparisons by gating them with a cheap deterministic proxy and surface proxy statistics for tuning. 
- Provide a small reproducible benchmark workflow to standardize measurements on a representative input.

### Description
- Added an internal reusable `ThreadPool` and replaced per-call spawn with `ParallelFor` in `third_party/butteraugli/.../butteraugli.cc`, plus `SetThreadCount`, `ThreadCount`, `ResetRuntimeProfile`, `GetRuntimeProfile` and `RuntimeProfile` (convolution calls / ms) to control and report threading and runtime profile. 
- Parallelized `butteraugli::Convolution` by splitting left/middle/right column work via `ParallelFor` and atomically accumulating convolution call & time metrics. 
- Introduced a deterministic cheap proxy path: added `ProxyDistance` to the comparator interface and implemented it in `ButteraugliComparator`, and used it in `Processor::SelectFrequencyMasking` to short-circuit full `Compare()` when the proxy strongly rejects a candidate (with an epsilon guard). 
- Gated all new wall-time instrumentation behind `--verbose` by checking `stats_->debug_output_file`, split `ButteraugliComparator::Compare` timing into conversion vs diffmap, added JPEG encode timing, extended `ProcessStats` fields, and printed the extra counters (including proxy_evals/proxy_rejects/full_compare_calls and butteraugli runtime profile) in verbose mode. 
- Added CLI `--threads N` and `GUETZLI_THREADS` support with default = hardware concurrency and clamped to `[1..64]`, and added `tools/mkbench.sh` to standardize creation of `/tmp/bench_800.jpg` (uses `ffmpeg` if available, otherwise safe copy-only fallback for already-small JPEGs).

### Testing
- Built successfully with `make -j4` (binary produced). 
- Ran `bash tests/smoke_test.sh bin/Release/guetzli` which failed in this environment due to missing external tools (`pngtopnm` and `cjpeg`). 
- Created benchmark input with `tools/mkbench.sh` to produce `/tmp/bench_800.jpg` (success). 
- Determinism: ran `bin/Release/guetzli --quality 90 /tmp/bench_800.jpg` twice and verified the generated JPEGs had identical `sha256sum` (success). 
- Threads scaling: measured single-run wall times using `--threads 1,2,4,8` on `/tmp/bench_800.jpg` and observed `1: 13.673s`, `2: 12.480s`, `4: 12.982s`, `8: 12.450s`. 
- 7-run median benchmark (default threads) on `/tmp/bench_800.jpg` produced median `11.998s` (measured `0.94x` vs user baseline `11.23s`). 
- Verbose instrumentation (representative run) printed: `Compare calls=215 total_ms=11785.557 avg_ms=54.817 color_ms=124.215 diffmap_ms=11661.303`, `SelectFrequencyMasking total_ms=11684.759 candidate_evals=421480 proxy_evals=205 full_compare_calls=205 proxy_rejects=0`, `butteraugli::Convolution calls=68360 total_ms=3943.696 threads=3`, and `JPEG encode calls=215 total_ms=145.668`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f265d24c0832985066c8a3f455609)